### PR TITLE
 lifestyle-advisor simplify UI changes

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,8 +7,9 @@ from dotenv import load_dotenv
 app = Flask(__name__)
 
 # Set up OpenAI API credentials
-load_dotenv()
-#openai_organization = os.getenv('OPENAI_ORGANIZATION') This one is not necessary for this App
+# load_dotenv()
+logging.basicConfig(filename='application.log', level=logging.DEBUG)
+#TODO get from environment
 openai_api_key = ''
 model_id = 'gpt-3.5-turbo'
 
@@ -87,7 +88,7 @@ def submit_form():
     if worthless:
         mytext += f"\nIn the past month, did you feel worthless? {worthless}."
 
-    print("mytext", mytext)
+    logging.debug(f"mytext{mytext}" )
 
     # Call the OpenAI API
     URL = "https://api.openai.com/v1/chat/completions"
@@ -106,14 +107,14 @@ def submit_form():
         "Authorization": f"Bearer "
     }
     response = requests.post(URL, headers=headers, json=payload, stream=False)
-    print("responseeeee", response)
+    logging.debug(f"response: {response}")
     
     # Process the API response and return the result
     if response.ok:
         response_data = response.json()
-        print("response_dataaaaaa", response_data)
+        logging.debug(f"response_dataaaaaa:{response_data}")
         generated_text = response_data["choices"][0]["message"]["content"].strip()
-        print("generated_textttt",generated_text)
+        logging.debug(f"generated_text{generated_text}")
         
         # Render the result template
         return render_template('results.html', generated_text=generated_text)

--- a/app.py
+++ b/app.py
@@ -1,8 +1,8 @@
 from flask import Flask, render_template, request
 import requests
-import openai
+import logging
 from dotenv import load_dotenv
-import os
+
 
 app = Flask(__name__)
 
@@ -20,7 +20,7 @@ def index():
 # Define the Flask route that handles the form submission
 @app.route('/submit', methods=['POST'])
 def submit_form():
-    print("form submitted")
+    logging.info("form submitted")
     # Get the form data from the request
     patient_height = request.form.get('height', '')
     weight = request.form.get('weight', '')

--- a/app.py
+++ b/app.py
@@ -1,14 +1,14 @@
 from flask import Flask, render_template, request
 import requests
-import logging
+import openai
 from dotenv import load_dotenv
+import os
 
 app = Flask(__name__)
 
 # Set up OpenAI API credentials
-# load_dotenv()
-logging.basicConfig(filename='application.log', level=logging.DEBUG)
-#TODO get from environment
+load_dotenv()
+#openai_organization = os.getenv('OPENAI_ORGANIZATION') This one is not necessary for this App
 openai_api_key = ''
 model_id = 'gpt-3.5-turbo'
 
@@ -20,12 +20,12 @@ def index():
 # Define the Flask route that handles the form submission
 @app.route('/submit', methods=['POST'])
 def submit_form():
-    logging.info("form submitted")
+    print("form submitted")
     # Get the form data from the request
-    height = request.form.get('height', '')
+    patient_height = request.form.get('height', '')
     weight = request.form.get('weight', '')
     age = request.form.get('age', '')
-    conditions = request.form.get('conditions', '')
+    symptoms = request.form.get('symptoms', '')
     gender = request.form.get('gender', '')
     walk = request.form.get('walk', '')
     exercise = request.form.get('exercise', '')
@@ -43,27 +43,28 @@ def submit_form():
     worthless = request.form.get('worthless', '')
 
     # Construct the mytext variable based only on non-empty and non-"prefer not to say" fields
-    mytext = "As an expert health advisor, prepare lifestyle advice for the Healthy life, for a person with the following characteristics:"
-    if height:
-        mytext += f" {height}cm tall"
+    mytext = "Prepare some lifestyle advice for the Healthy life, for a person with the following characteristics:"
+    if patient_height:
+        mytext += f" {patient_height}cm tall"
     if weight:
         mytext += f" weights {weight}kg"
     if age:
         mytext += f" and is a {age}-year-old"
     if gender:
         mytext += f" {gender}"
-    if conditions:
-        mytext += f" following health conditions {conditions}"
+        # If "prefer not to say" is selected, set gender to an empty string
+    if gender == 'prefer_not_to_say':
+        gender = ''
     mytext += ". This person took the following lifestyle and medical history questionnaire and next to each question is the answer obtained. Your essay please separate it into Introduction, Exercise, Sleep, Diet, Communication, Alcohol, Hobbies, Mental Health and Conclusion sections."
-    if walk:
+    if walk and walk != 'I dont know':  # Exclude 'I dont know'
         mytext += f"\nPhysical Activity:\nHow much do you walk everyday? {walk}."
-    if exercise and exercise != 'prefer not to say':
+    if exercise and exercise != 'I dont know':  # Exclude 'I dont know'
         mytext += f"\nIn a week how many times you exercise more than 30 minutes? {exercise}."
-    if fruits_veggies:
+    if fruits_veggies and fruits_veggies != 'I dont know':  # Exclude 'I dont know'
         mytext += f"\nDiet:\nEveryday how many portions of fruits and vegetables do you eat? {fruits_veggies}."
     if diet and diet != 'prefer not to say':
-        mytext += f"\nThe person follows {diet} diet."
-    if sleep and sleep != 'prefer not to say':
+        mytext += f"\nWhat diet do you follow?{diet}"
+    if sleep and sleep != 'I dont know':  # Exclude 'I dont know'
         mytext += f"\nSleep:\nIn the past months, how would you qualify your own sleep? {sleep}."
         if sleep_reason:
             mytext += "\nWhich of the following reasons apply to your sleep? Select all that apply."
@@ -74,19 +75,19 @@ def submit_form():
     if diabetes:
         mytext += f"\nHave you ever been told you have diabetes? Or are you on treatment for diabetes? {diabetes}."
     if smoking:
-        mytext += f"\nDo you smoke? {smoking}."
+        mytext += f"\nDo you smoke or consume tobaco? {smoking}."
     if alcohol and alcohol != 'prefer not to say':
         mytext += f"\nHow much alcohol do you drink per day? {alcohol}."
     if nervous:
         mytext += f"\nMental Health:\nIn the past month, did you feel nervous?{nervous}."
-    if depressed:
+    if depressed and depressed != 'I dont know':  # Exclude 'I dont know'
         mytext += f"\nIn the past month, did you feel depressed and like nothing could make you feel better? {depressed}."
     if difficult:
         mytext += f"\nIn the past month, did you feel that anything you did was foolish?{difficult}."
     if worthless:
         mytext += f"\nIn the past month, did you feel worthless? {worthless}."
 
-    logging.debug(f"mytext{mytext}" )
+    print("mytext", mytext)
 
     # Call the OpenAI API
     URL = "https://api.openai.com/v1/chat/completions"
@@ -102,17 +103,17 @@ def submit_form():
     }
     headers = {
         "Content-Type": "application/json",
-        "Authorization": f"Bearer {openai_api_key}"
+        "Authorization": f"Bearer "
     }
     response = requests.post(URL, headers=headers, json=payload, stream=False)
-    logging.debug(f"response: {response}")
+    print("responseeeee", response)
     
     # Process the API response and return the result
     if response.ok:
         response_data = response.json()
-        logging.debug(f"response_dataaaaaa:{response_data}")
+        print("response_dataaaaaa", response_data)
         generated_text = response_data["choices"][0]["message"]["content"].strip()
-        logging.debug(f"generated_text{generated_text}")
+        print("generated_textttt",generated_text)
         
         # Render the result template
         return render_template('results.html', generated_text=generated_text)

--- a/static/style.css
+++ b/static/style.css
@@ -115,3 +115,48 @@
 	}
   }
   
+  
+
+.input-groups {
+    display: flex;
+    align-items: center;
+}
+.input-groups p {
+    margin: 10;
+    padding-right: 100px;
+}
+
+.input-groups label {
+    display: inline-block;
+    width: 150px; /* Adjust the width as needed */
+    text-align: left; /* Align the label text to the right */
+    margin-right: 10px; /* Add some space between the label and input */
+}
+.input-groups input {
+    width: 200px; /* Adjust the width as needed */
+}
+
+
+
+
+
+
+.input-groupss {
+    display: flex;
+    align-items: center;
+}
+
+.input-groupss label {
+    margin-right: 40px;
+}
+
+.radio-groupss {
+    display: flex;
+    align-items: center;
+    margin-top: 15px; /* Adjust top margin as needed */
+}
+
+.radio-groupss label {
+    margin-right: 30px; /* Adjust margin between radio options */
+}
+

--- a/templates/form.html
+++ b/templates/form.html
@@ -1,207 +1,224 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>HealthGuide</title>
+    <title>Lifestyle-advisor</title>
     <link rel="stylesheet" type="text/css" href="static/style.css">
 </head>
 <body>
-    <h1>HealthGuide</h1>
-    <form action="/submit" method="POST" onsubmit="showLoadingSpinner()">
-        
-        <label for="age">Age(in number):</label>
-        <input type="number" id="age" placeholder="21" value="Default Age" required>
+  <h1>Lifestyle-advisor</h1>
+  <form action="/submit" method="POST" onsubmit="showLoadingSpinner()">
+      
+    <div class="input-group">
+      <label for="age">Age (in number):</label>
+      <input type="number" id="age" placeholder="21" value="Default Age" required>
+  </div>
 
-        <p>Gender:</p>
-        <div class="radio-group">
-          <label><input type="radio" name="gender" value="male"  required>Male</label>
-          <label><input type="radio" name="gender" value="female" required>Female</label>
-        </div>
+      <p>Gender:</p>
+      <div class="radio-group">
+        <label><input type="radio" name="gender" value="male"  required>Male</label>
+        <label><input type="radio" name="gender" value="female" required>Female</label>
+        <label><input type="radio" name="gender" value="prefer not to say" required>prefer not to say</label>
+      </div>
 
-        <label for="conditions">Health conditions (in word):</label>
-        <input type="words" id="conditions" name="conditions"  required><br>
+      <label for="symptoms">Symptoms (in word):</label>
+      <input type="words" id="symptoms" name="symptoms"  required><br>
 
-        <label for="height">Height (in cm):</label>
-        <input type="number" id="height" name="height">
-        
-        <label for="weight">Weight (in kg):</label>
-        <input type="number" id="weight" name="weight">
-    
+      <label for="height">Height (in cm):</label>
+      <input type="number" id="height" name="height">
+      
+      <label for="weight">Weight (in kg):</label>
+      <input type="number" id="weight" name="weight">
   
 
-    
+<!-- Button to toggle visibility of More Details section -->
+<button id="toggle-details" type="button" onclick="toggleDetails()">More Details</button>
+
+
+  <!-- More Details section -->
+<section id="more-details" style="display: none;">
 <p>How much do you walk every day?</p>
 <div class="radio-group">
-  <label><input type="radio" name="walk" value="Less than 15 mins" required>Less than 15 mins</label>
-  <label><input type="radio" name="walk" value="Between 15-30 mins" required>Between 15-30 mins</label>
-  <label><input type="radio" name="walk" value="Between 30-45 mins" required>Between 30-45 mins</label>
-  <label><input type="radio" name="walk" value="Between 45-60 mins" required>Between 45-60 mins</label>
-  <label><input type="radio" name="walk" value="More than 60 mins" required>More than 60 mins</label>
-  <label><input type="radio" name="walk" value="prefer not to say" checked required>prefer not to say</label>
+<label><input type="radio" name="walk" value="Less than 15 mins" required>Less than 15 mins</label>
+<label><input type="radio" name="walk" value="Between 15-30 mins" required>Between 15-30 mins</label>
+<label><input type="radio" name="walk" value="Between 30-45 mins" required>Between 30-45 mins</label>
+<label><input type="radio" name="walk" value="Between 45-60 mins" required>Between 45-60 mins</label>
+<label><input type="radio" name="walk" value="More than 60 mins" required>More than 60 mins</label>
+<label><input type="radio" name="walk" value="I dont know" checked required>I dont know</label>
 </div>
 
 <p>In a week how many times you exercise more than 30 minutes?</p>
 <div class="radio-group">
-  <label><input type="radio" name="exercise" value="less than 1 day" required>Less than 1 day</label>
-  <label><input type="radio" name="exercise" value="1 day" required>1 day</label>
-  <label><input type="radio" name="exercise" value="2 days" required>2 days</label>
-  <label><input type="radio" name="exercise" value="3 days" required>3 days</label>
-  <label><input type="radio" name="exercise" value="4 days or more" required>4 days or more</label>
-  <label><input type="radio" name="exercise" value="prefer not to say" checked required>prefer not to say</label>
+<label><input type="radio" name="exercise" value="less than 1 day" required>Less than 1 day</label>
+<label><input type="radio" name="exercise" value="1 day" required>1 day</label>
+<label><input type="radio" name="exercise" value="2 days" required>2 days</label>
+<label><input type="radio" name="exercise" value="3 days" required>3 days</label>
+<label><input type="radio" name="exercise" value="4 days or more" required>4 days or more</label>
+<label><input type="radio" name="exercise" value="I dont know" checked required>I dont know</label>
 </div>
 
 <div class="radio-group">
-    <p>Everyday how many portions of fruits and vegetables do you eat?</p>
-    <label><input type="radio" name="fruits_veggies" value="less than 1" required>Less than 1</label>
-    <label><input type="radio" name="fruits_veggies" value="2 portions" required>2 portions</label>
-    <label><input type="radio" name="fruits_veggies" value="3 portions" required>3 portions</label>
-    <label><input type="radio" name="fruits_veggies" value="4 portions" required>4 portions</label>
-    <label><input type="radio" name="fruits_veggies" value="5 or more portions required">5 or more portions</label>
-    <label><input type="radio" name="fruits_veggies" value="prefer not to say" checked required>prefer not to say</label>
-  </div>
-  
-  <div class="radio-group">
-    <p>The person follows (selected_diet)</p>
-    <label><input type="radio" name="diet" value="vegetarian" required>vegetarian</label>
-    <label><input type="radio" name="diet" value="eggetarian">eggetarian</label>
-    <label><input type="radio" name="diet" value="vegan" required>vegan</label>
-    <label><input type="radio" name="diet" value="non-vegetarian" required>non-vegetarian</label>
-    <label><input type="radio" name="diet" value="prefer not to say" checked required>prefer not to say</label>
-  </div>
-  
+  <p>Everyday how many portions of fruits and vegetables do you eat?</p>
+  <label><input type="radio" name="fruits_veggies" value="less than 1" required>Less than 1</label>
+  <label><input type="radio" name="fruits_veggies" value="2 portions" required>2 portions</label>
+  <label><input type="radio" name="fruits_veggies" value="3 portions" required>3 portions</label>
+  <label><input type="radio" name="fruits_veggies" value="4 portions" required>4 portions</label>
+  <label><input type="radio" name="fruits_veggies" value="5 or more portions required">5 or more portions</label>
+  <label><input type="radio" name="fruits_veggies" value="I dont know" checked required>I dont know</label>
+</div>
 
-  <p>In the past month, how would you qualify your own sleep?</p>
-  <div class="radio-group">
-    <label><input type="radio" name="sleep" value="extremely good" required>Extremely good</label>
-    <label><input type="radio" name="sleep" value="normal" required>Normal</label>
-    <label><input type="radio" name="sleep" value="bad" required>Bad</label>
-    <label><input type="radio" name="sleep" value="very bad" required>Very bad</label>
-    <label><input type="radio" name="sleep" value="prefer not to say" checked required>prefer not to say</label>
-  </div>
-  
+<div class="radio-group">
+  <p>What diet do you follow?</p>
+  <label><input type="radio" name="diet" value="vegetarian" required>vegetarian</label>
+  <label><input type="radio" name="diet" value="eggetarian">eggetarian</label>
+  <label><input type="radio" name="diet" value="vegan" required>vegan</label>
+  <label><input type="radio" name="diet" value="non-vegetarian" required>non-vegetarian</label>
+  <label><input type="radio" name="diet" value="prefer not to say" checked required>prefer not to say</label>
+</div>
+
+
+<p>In the past month, how would you qualify your own sleep?</p>
+<div class="radio-group">
+  <label><input type="radio" name="sleep" value="extremely good" required>Extremely good</label>
+  <label><input type="radio" name="sleep" value="normal" required>Normal</label>
+  <label><input type="radio" name="sleep" value="bad" required>Bad</label>
+  <label><input type="radio" name="sleep" value="very bad" required>Very bad</label>
+  <label><input type="radio" name="sleep" value="I dont know" checked required>I dont know</label>
+</div>
+
 <p>Which of the following reasons apply to your sleep? Select all that apply. </p>
 <div class="radio-group">
-  <label><input type="checkbox" name="sleep_reason[]" value="I snore louder than my speaking voice" >I snore louder than my speaking voice</label><br>
-  <label><input type="checkbox" name="sleep_reason[]" value="fatigue and daytime sleepiness" >Fatigue and daytime sleepiness</label><br>
-  <label><input type="checkbox" name="sleep_reason[]" value="Shortness of breath during sleep" >Shortness of breath during sleep</label><br>
-  <label><input type="checkbox" name="sleep_reason[]" id="none-checkbox" value="none of the above" >None of the above</label><br>
-  <label><input type="checkbox" name="sleep_reason[]" value="prefer not to say" checked >prefer not to say</label><br>
+<label><input type="checkbox" name="sleep_reason[]" value="I snore louder than my speaking voice" >I snore louder than my speaking voice</label><br>
+<label><input type="checkbox" name="sleep_reason[]" value="fatigue and daytime sleepiness" >Fatigue and daytime sleepiness</label><br>
+<label><input type="checkbox" name="sleep_reason[]" value="Shortness of breath during sleep" >Shortness of breath during sleep</label><br>
+<label><input type="checkbox" name="sleep_reason[]" id="none-checkbox" value="none of the above" checked>None of the above</label><br>
 </div>
-        <script>
-        const noneCheckbox = document.getElementById("none-checkbox");
-        const otherCheckboxes = document.querySelectorAll('input[name="sleep_reason[]"]:not(#none-checkbox)');
-        
-        noneCheckbox.addEventListener("change", function() {
-            if (this.checked) {
-                // If "none of the above" is checked, uncheck all other options
-                otherCheckboxes.forEach(function(el) {
-                    el.checked = false;
-                });
-            } else {
-                // If "none of the above" is unchecked, check if any other options are checked
-                const anyOtherChecked = Array.from(otherCheckboxes).some(function(el) {
-                    return el.checked;
-                });
-                if (anyOtherChecked) {
-                    // If at least one other option is checked, leave "none of the above" unchecked
-                    return;
-                } else {
-                    // If no other options are checked, check "none of the above"
-                    this.checked = true;
-                }
-            }
-        });
-        
-        otherCheckboxes.forEach(function(el) {
-            el.addEventListener("change", function() {
-                // If any other option is checked, uncheck "none of the above"
-                noneCheckbox.checked = false;
-            });
-        });
-        </script>
-        
-        <p>Have you ever been told you have hypertension? Or are you on treatment for hypertension?</p>
-        <div class="radio-group">
-          <label><input type="radio" name="hypertension" value="yes" required>Yes</label>
-          <label><input type="radio" name="hypertension" value="no" required>No</label>
-          <label><input type="radio" name="hypertension" value="prefer not to say" checked required>prefer not to say</label>
-        </div>
-        
-        <p>Have you ever been told you have diabetes? Or are you on treatment for diabetes?</p>
-        <div class="radio-group">
-          <label><input type="radio" name="diabetes" value="yes" required>Yes</label>
-          <label><input type="radio" name="diabetes" value="no" required>No</label>
-          <label><input type="radio" name="diabetes" value="prefer not to say" checked required>prefer not to say</label>
-        </div>
-        
-        <p>Do you smoke?</p>
-        <div class="radio-group">
-          <label><input type="radio" name="smoking" value="yes" required>Yes</label>
-          <label><input type="radio" name="smoking" value="no" required>No</label>
-          <label><input type="radio" name="smoking" value="prefer not to say" checked required>prefer not to say</label>
-        </div>
+      <script>
+      const noneCheckbox = document.getElementById("none-checkbox");
+      const otherCheckboxes = document.querySelectorAll('input[name="sleep_reason[]"]:not(#none-checkbox)');
+      
+      noneCheckbox.addEventListener("change", function() {
+          if (this.checked) {
+              // If "none of the above" is checked, uncheck all other options
+              otherCheckboxes.forEach(function(el) {
+                  el.checked = false;
+              });
+          } else {
+              // If "none of the above" is unchecked, check if any other options are checked
+              const anyOtherChecked = Array.from(otherCheckboxes).some(function(el) {
+                  return el.checked;
+              });
+              if (anyOtherChecked) {
+                  // If at least one other option is checked, leave "none of the above" unchecked
+                  return;
+              } else {
+                  // If no other options are checked, check "none of the above"
+                  this.checked = true;
+              }
+          }
+      });
+      
+      otherCheckboxes.forEach(function(el) {
+          el.addEventListener("change", function() {
+              // If any other option is checked, uncheck "none of the above"
+              noneCheckbox.checked = false;
+          });
+      });
+      </script>
+      
+      <p>Have you ever been told you have hypertension? Or are you on treatment for hypertension?</p>
+      <div class="radio-group">
+        <label><input type="radio" name="hypertension" value="yes" required>Yes</label>
+        <label><input type="radio" name="hypertension" value="no" checked required>No</label>
+      </div>
+      
+      <p>Have you ever been told you have diabetes? Or are you on treatment for diabetes?</p>
+      <div class="radio-group">
+        <label><input type="radio" name="diabetes" value="yes" required>Yes</label>
+        <label><input type="radio" name="diabetes" value="no" checked required>No</label>
+      </div>
+      
+      <p>Do you smoke or consume tobaco?</p>
+      <div class="radio-group">
+        <label><input type="radio" name="smoking" value="yes" required>Yes</label>
+        <label><input type="radio" name="smoking" value="no" checked required>No</label>
+      </div>
 
-        <p>How much alcohol do you drink per day?</p>
-        <div class="radio-group">
-          <label><input type="radio" name="alcohol" value="don't drink at all" required>Don't drink at all</label>
-          <label><input type="radio" name="alcohol" value="less than half a cup" required>Less than half a cup</label>
-          <label><input type="radio" name="alcohol" value="between half and 1 cups" required>Between half and 1 cups</label>
-          <label><input type="radio" name="alcohol" value="between 1 and 2 cups" required>Between 1 and 2 cups</label>
-          <label><input type="radio" name="alcohol" value="2 or more cups" required>2 or more cups</label>
-          <label><input type="radio" name="alcohol" value="prefer not to say" checked required>prefer not to say</label>
-        </div>
+      <p>How much alcohol do you drink per day?</p>
+      <div class="radio-group">
+        <label><input type="radio" name="alcohol" value="don't drink at all" checked required>Don't drink at all</label>
+        <label><input type="radio" name="alcohol" value="less than half a cup" required>Less than half a cup</label>
+        <label><input type="radio" name="alcohol" value="between half and 1 cups" required>Between half and 1 cups</label>
+        <label><input type="radio" name="alcohol" value="between 1 and 2 cups" required>Between 1 and 2 cups</label>
+        <label><input type="radio" name="alcohol" value="2 or more cups" required>2 or more cups</label>
+      </div>
 
-        <p>In the past month, did you feel nervous?</p>
-        <div class="radio-group">
-          <label><input type="radio" name="nervous" value="Not at all" required>Not at all</label>
-          <label><input type="radio" name="nervous" value="Just a little" required>Just a little</label>
-          <label><input type="radio" name="nervous" value="Sometimes" required>Sometimes</label>
-          <label><input type="radio" name="nervous" value="Generally" required>Generally</label>
-          <label><input type="radio" name="nervous" value="Every time" required>Every time</label>
-          <label><input type="radio" name="nervous" value="prefer not to say" checked required>prefer not to say</label>
-        </div>
+      <p>In the past month, did you feel nervous?</p>
+      <div class="radio-group">
+        <label><input type="radio" name="nervous" value="Not at all" checked required>Not at all</label>
+        <label><input type="radio" name="nervous" value="Just a little" required>Just a little</label>
+        <label><input type="radio" name="nervous" value="Sometimes" required>Sometimes</label>
+        <label><input type="radio" name="nervous" value="Generally" required>Generally</label>
+        <label><input type="radio" name="nervous" value="Every time" required>Every time</label>
+      </div>
 
-        <p>In the past month, did you feel depressed and like nothing could make you feel better?</p>
-        <div class="radio-group">
-            <label><input type="radio" name="depressed" value="Not at all" required>Not at all</label>
-            <label><input type="radio" name="depressed" value="Just a little" required>Just a little</label>
-            <label><input type="radio" name="depressed" value="Sometimes" required>Sometimes</label>
-            <label><input type="radio" name="depressed" value="Generally" required>Generally</label>
-            <label><input type="radio" name="depressed" value="Every time" required>Every time</label>
-            <label><input type="radio" name="depressed" value="prefer not to say" checked required>prefer not to say</label>
-        </div>
-        
-        <p>In the past month, did you feel that anything you did was foolish?</p>
-        <div class="radio-group">
-            <label><input type="radio" name="difficult" value="Not at all" required>Not at all</label>
-            <label><input type="radio" name="difficult" value="Just a little" required>Just a little</label>
-            <label><input type="radio" name="difficult" value="Sometimes" required>Sometimes</label>
-            <label><input type="radio" name="difficult" value="Generally" required>Generally</label>
-            <label><input type="radio" name="difficult" value="Every time" required>Every time</label>
-            <label><input type="radio" name="difficult" value="prefer not to say" checked required>prefer not to say</label>
-        </div>
-        
-        <p>In the past month, did you feel worthless?</p>
-        <div class="radio-group">
-            <label><input type="radio" name="worthless" value="Not at all" required>Not at all</label>
-            <label><input type="radio" name="worthless" value="Just a little" required>Just a little</label>
-            <label><input type="radio" name="worthless" value="Sometimes" required>Sometimes</label>
-            <label><input type="radio" name="worthless" value="Generally" required>Generally</label>
-            <label><input type="radio" name="worthless" value="Every time" required>Every time</label>
-            <label><input type="radio" name="worthless" value="prefer not to say" checked required>prefer not to say</label>
-        </div>
+      <p>In the past month, did you feel depressed and like nothing could make you feel better?</p>
+      <div class="radio-group">
+          <label><input type="radio" name="depressed" value="Not at all" required>Not at all</label>
+          <label><input type="radio" name="depressed" value="Just a little" required>Just a little</label>
+          <label><input type="radio" name="depressed" value="Sometimes" required>Sometimes</label>
+          <label><input type="radio" name="depressed" value="Generally" required>Generally</label>
+          <label><input type="radio" name="depressed" value="Every time" required>Every time</label>
+          <label><input type="radio" name="depressed" value="I dont know" checked required>I dont know</label>
+      </div>
+      
+      <p>In the past month, did you feel that anything you did was foolish?</p>
+      <div class="radio-group">
+          <label><input type="radio" name="difficult" value="Not at all" checked required>Not at all</label>
+          <label><input type="radio" name="difficult" value="Just a little" required>Just a little</label>
+          <label><input type="radio" name="difficult" value="Sometimes" required>Sometimes</label>
+          <label><input type="radio" name="difficult" value="Generally" required>Generally</label>
+          <label><input type="radio" name="difficult" value="Every time" required>Every time</label>
+      </div>
+      
+      <p>In the past month, did you feel worthless?</p>
+      <div class="radio-group">
+          <label><input type="radio" name="worthless" value="Not at all" checked required>Not at all</label>
+          <label><input type="radio" name="worthless" value="Just a little" required>Just a little</label>
+          <label><input type="radio" name="worthless" value="Sometimes" required>Sometimes</label>
+          <label><input type="radio" name="worthless" value="Generally" required>Generally</label>
+          <label><input type="radio" name="worthless" value="Every time" required>Every time</label>
+      </div>
+    </section>
 
-        <!-- Add a div with a unique ID to show the loading spinner -->
-        <div id="loading-spinner" class="hidden">
-            <div class="spinner"></div>
-        </div>
 
-        <input type="submit" value="Submit">
-    </form>
-    <script>
-        function showLoadingSpinner() {
-            // Show the loading spinner when the form is submitted
-            document.getElementById("loading-spinner").classList.remove("hidden");
-        }
-    </script>
+      <!-- Add a div with a unique ID to show the loading spinner -->
+      <div id="loading-spinner" class="hidden">
+          <div class="spinner"></div>
+      </div>
+
+      <input type="submit" value="Submit">
+  </form>
+  <script>
+      function showLoadingSpinner() {
+          // Show the loading spinner when the form is submitted
+          document.getElementById("loading-spinner").classList.remove("hidden");
+      }
+  </script>
+
+<script>
+function toggleDetails() {
+    var detailsSection = document.getElementById("more-details");
+    var toggleButton = document.getElementById("toggle-details");
+
+    if (detailsSection.style.display === "none") {
+        detailsSection.style.display = "block";
+        toggleButton.textContent = "Less Details";
+    } else {
+        detailsSection.style.display = "none";
+        toggleButton.textContent = "More Details";
+    }
+}
+</script>
+
 </body>
 </html>

--- a/templates/form.html
+++ b/templates/form.html
@@ -5,220 +5,229 @@
     <link rel="stylesheet" type="text/css" href="static/style.css">
 </head>
 <body>
-  <h1>Lifestyle-advisor</h1>
-  <form action="/submit" method="POST" onsubmit="showLoadingSpinner()">
-      
-    <div class="input-group">
-      <label for="age">Age (in number):</label>
-      <input type="number" id="age" placeholder="21" value="Default Age" required>
-  </div>
-
-      <p>Gender:</p>
-      <div class="radio-group">
-        <label><input type="radio" name="gender" value="male"  required>Male</label>
-        <label><input type="radio" name="gender" value="female" required>Female</label>
-        <label><input type="radio" name="gender" value="prefer not to say" required>prefer not to say</label>
+      <h1>Lifestyle-advisor</h1>
+      <form action="/submit" method="POST" onsubmit="showLoadingSpinner()">
+          
+        <div class="input-groups">
+          <p><label for="age">Age (in number):</label></p>
+          <input type="number" id="age" placeholder="21" value="Default Age" required>
       </div>
-
-      <label for="symptoms">Symptoms (in word):</label>
-      <input type="words" id="symptoms" name="symptoms"  required><br>
-
-      <label for="height">Height (in cm):</label>
-      <input type="number" id="height" name="height">
-      
-      <label for="weight">Weight (in kg):</label>
-      <input type="number" id="weight" name="weight">
   
-
-<!-- Button to toggle visibility of More Details section -->
-<button id="toggle-details" type="button" onclick="toggleDetails()">More Details</button>
-
-
-  <!-- More Details section -->
-<section id="more-details" style="display: none;">
-<p>How much do you walk every day?</p>
-<div class="radio-group">
-<label><input type="radio" name="walk" value="Less than 15 mins" required>Less than 15 mins</label>
-<label><input type="radio" name="walk" value="Between 15-30 mins" required>Between 15-30 mins</label>
-<label><input type="radio" name="walk" value="Between 30-45 mins" required>Between 30-45 mins</label>
-<label><input type="radio" name="walk" value="Between 45-60 mins" required>Between 45-60 mins</label>
-<label><input type="radio" name="walk" value="More than 60 mins" required>More than 60 mins</label>
-<label><input type="radio" name="walk" value="I dont know" checked required>I dont know</label>
-</div>
-
-<p>In a week how many times you exercise more than 30 minutes?</p>
-<div class="radio-group">
-<label><input type="radio" name="exercise" value="less than 1 day" required>Less than 1 day</label>
-<label><input type="radio" name="exercise" value="1 day" required>1 day</label>
-<label><input type="radio" name="exercise" value="2 days" required>2 days</label>
-<label><input type="radio" name="exercise" value="3 days" required>3 days</label>
-<label><input type="radio" name="exercise" value="4 days or more" required>4 days or more</label>
-<label><input type="radio" name="exercise" value="I dont know" checked required>I dont know</label>
-</div>
-
-<div class="radio-group">
-  <p>Everyday how many portions of fruits and vegetables do you eat?</p>
-  <label><input type="radio" name="fruits_veggies" value="less than 1" required>Less than 1</label>
-  <label><input type="radio" name="fruits_veggies" value="2 portions" required>2 portions</label>
-  <label><input type="radio" name="fruits_veggies" value="3 portions" required>3 portions</label>
-  <label><input type="radio" name="fruits_veggies" value="4 portions" required>4 portions</label>
-  <label><input type="radio" name="fruits_veggies" value="5 or more portions required">5 or more portions</label>
-  <label><input type="radio" name="fruits_veggies" value="I dont know" checked required>I dont know</label>
-</div>
-
-<div class="radio-group">
-  <p>What diet do you follow?</p>
-  <label><input type="radio" name="diet" value="vegetarian" required>vegetarian</label>
-  <label><input type="radio" name="diet" value="eggetarian">eggetarian</label>
-  <label><input type="radio" name="diet" value="vegan" required>vegan</label>
-  <label><input type="radio" name="diet" value="non-vegetarian" required>non-vegetarian</label>
-  <label><input type="radio" name="diet" value="prefer not to say" checked required>prefer not to say</label>
-</div>
-
-
-<p>In the past month, how would you qualify your own sleep?</p>
-<div class="radio-group">
-  <label><input type="radio" name="sleep" value="extremely good" required>Extremely good</label>
-  <label><input type="radio" name="sleep" value="normal" required>Normal</label>
-  <label><input type="radio" name="sleep" value="bad" required>Bad</label>
-  <label><input type="radio" name="sleep" value="very bad" required>Very bad</label>
-  <label><input type="radio" name="sleep" value="I dont know" checked required>I dont know</label>
-</div>
-
-<p>Which of the following reasons apply to your sleep? Select all that apply. </p>
-<div class="radio-group">
-<label><input type="checkbox" name="sleep_reason[]" value="I snore louder than my speaking voice" >I snore louder than my speaking voice</label><br>
-<label><input type="checkbox" name="sleep_reason[]" value="fatigue and daytime sleepiness" >Fatigue and daytime sleepiness</label><br>
-<label><input type="checkbox" name="sleep_reason[]" value="Shortness of breath during sleep" >Shortness of breath during sleep</label><br>
-<label><input type="checkbox" name="sleep_reason[]" id="none-checkbox" value="none of the above" checked>None of the above</label><br>
-</div>
-      <script>
-      const noneCheckbox = document.getElementById("none-checkbox");
-      const otherCheckboxes = document.querySelectorAll('input[name="sleep_reason[]"]:not(#none-checkbox)');
       
-      noneCheckbox.addEventListener("change", function() {
-          if (this.checked) {
-              // If "none of the above" is checked, uncheck all other options
-              otherCheckboxes.forEach(function(el) {
-                  el.checked = false;
-              });
-          } else {
-              // If "none of the above" is unchecked, check if any other options are checked
-              const anyOtherChecked = Array.from(otherCheckboxes).some(function(el) {
-                  return el.checked;
-              });
-              if (anyOtherChecked) {
-                  // If at least one other option is checked, leave "none of the above" unchecked
-                  return;
+        <div class="input-groupss">
+          <p><label for="Gender">Gender:</label></p>
+          <div class="radio-group">
+            <label><input type="radio" name="gender" value="male"  required>Male</label>
+            <label><input type="radio" name="gender" value="female" required>Female</label>
+            <label><input type="radio" name="gender" value="prefer not to say" required>prefer not to say</label>
+          </div>
+        </div>
+  
+  
+        
+  
+          <p><label for="symptoms">Symptoms (in words):</label></p>
+  <textarea id="symptoms" name="symptoms" rows="4" cols="50" required></textarea><br>
+  
+  <!-- Button to toggle visibility of More Details section -->
+  <button id="toggle-details" type="button" onclick="toggleDetails()">More Details</button>
+  
+  
+          <!-- More Details section -->
+  <section id="more-details" style="display: none;">
+    
+  
+          <p><label for="height">Height (in cm):</label></p>
+          <input type="number" id="height" name="height">
+          
+          <p><label for="weight">Weight (in kg):</label></p>
+          <input type="number" id="weight" name="weight">
+    
+    
+  <p>How much do you walk every day?</p>   
+  <div class="radio-group">
+    <label><input type="radio" name="walk" value="Less than 15 mins" required>Less than 15 mins</label>
+    <label><input type="radio" name="walk" value="Between 15-30 mins" required>Between 15-30 mins</label>
+    <label><input type="radio" name="walk" value="Between 30-45 mins" required>Between 30-45 mins</label>
+    <label><input type="radio" name="walk" value="Between 45-60 mins" required>Between 45-60 mins</label>
+    <label><input type="radio" name="walk" value="More than 60 mins" required>More than 60 mins</label>
+    <label><input type="radio" name="walk" value="I dont know" checked required>I dont know</label>
+  </div>
+  
+  <p>In a week how many times you exercise more than 30 minutes?</p>
+  <div class="radio-group">
+    <label><input type="radio" name="exercise" value="less than 1 day" required>Less than 1 day</label>
+    <label><input type="radio" name="exercise" value="1 day" required>1 day</label>
+    <label><input type="radio" name="exercise" value="2 days" required>2 days</label>
+    <label><input type="radio" name="exercise" value="3 days" required>3 days</label>
+    <label><input type="radio" name="exercise" value="4 days or more" required>4 days or more</label>
+    <label><input type="radio" name="exercise" value="I dont know" checked required>I dont know</label>
+  </div>
+  
+  <div class="radio-group">
+      <p>Everyday how many portions of fruits and vegetables do you eat?</p>
+      <label><input type="radio" name="fruits_veggies" value="less than 1" required>Less than 1</label>
+      <label><input type="radio" name="fruits_veggies" value="2 portions" required>2 portions</label>
+      <label><input type="radio" name="fruits_veggies" value="3 portions" required>3 portions</label>
+      <label><input type="radio" name="fruits_veggies" value="4 portions" required>4 portions</label>
+      <label><input type="radio" name="fruits_veggies" value="5 or more portions required">5 or more portions</label>
+      <label><input type="radio" name="fruits_veggies" value="I dont know" checked required>I dont know</label>
+    </div>
+    
+    <div class="radio-group">
+      <p>What diet do you follow?</p>
+      <label><input type="radio" name="diet" value="vegetarian" required>vegetarian</label>
+      <label><input type="radio" name="diet" value="eggetarian">eggetarian</label>
+      <label><input type="radio" name="diet" value="vegan" required>vegan</label>
+      <label><input type="radio" name="diet" value="non-vegetarian" required>non-vegetarian</label>
+      <label><input type="radio" name="diet" value="prefer not to say" checked required>prefer not to say</label>
+    </div>
+    
+  
+    <p>In the past month, how would you qualify your own sleep?</p>
+    <div class="radio-group">
+      <label><input type="radio" name="sleep" value="extremely good" required>Extremely good</label>
+      <label><input type="radio" name="sleep" value="normal" required>Normal</label>
+      <label><input type="radio" name="sleep" value="bad" required>Bad</label>
+      <label><input type="radio" name="sleep" value="very bad" required>Very bad</label>
+      <label><input type="radio" name="sleep" value="I dont know" checked required>I dont know</label>
+    </div>
+    
+  <p>Which of the following reasons apply to your sleep? Select all that apply. </p>
+  <div class="radio-group">
+    <label><input type="checkbox" name="sleep_reason[]" value="I snore louder than my speaking voice" >I snore louder than my speaking voice</label><br>
+    <label><input type="checkbox" name="sleep_reason[]" value="fatigue and daytime sleepiness" >Fatigue and daytime sleepiness</label><br>
+    <label><input type="checkbox" name="sleep_reason[]" value="Shortness of breath during sleep" >Shortness of breath during sleep</label><br>
+    <label><input type="checkbox" name="sleep_reason[]" id="none-checkbox" value="none of the above" checked>None of the above</label><br>
+  </div>
+          <script>
+          const noneCheckbox = document.getElementById("none-checkbox");
+          const otherCheckboxes = document.querySelectorAll('input[name="sleep_reason[]"]:not(#none-checkbox)');
+          
+          noneCheckbox.addEventListener("change", function() {
+              if (this.checked) {
+                  // If "none of the above" is checked, uncheck all other options
+                  otherCheckboxes.forEach(function(el) {
+                      el.checked = false;
+                  });
               } else {
-                  // If no other options are checked, check "none of the above"
-                  this.checked = true;
+                  // If "none of the above" is unchecked, check if any other options are checked
+                  const anyOtherChecked = Array.from(otherCheckboxes).some(function(el) {
+                      return el.checked;
+                  });
+                  if (anyOtherChecked) {
+                      // If at least one other option is checked, leave "none of the above" unchecked
+                      return;
+                  } else {
+                      // If no other options are checked, check "none of the above"
+                      this.checked = true;
+                  }
               }
-          }
-      });
-      
-      otherCheckboxes.forEach(function(el) {
-          el.addEventListener("change", function() {
-              // If any other option is checked, uncheck "none of the above"
-              noneCheckbox.checked = false;
           });
-      });
+          
+          otherCheckboxes.forEach(function(el) {
+              el.addEventListener("change", function() {
+                  // If any other option is checked, uncheck "none of the above"
+                  noneCheckbox.checked = false;
+              });
+          });
+          </script>
+          
+          <p>Have you ever been told you have hypertension? Or are you on treatment for hypertension?</p>
+          <div class="radio-group">
+            <label><input type="radio" name="hypertension" value="yes" required>Yes</label>
+            <label><input type="radio" name="hypertension" value="no" checked required>No</label>
+          </div>
+          
+          <p>Have you ever been told you have diabetes? Or are you on treatment for diabetes?</p>
+          <div class="radio-group">
+            <label><input type="radio" name="diabetes" value="yes" required>Yes</label>
+            <label><input type="radio" name="diabetes" value="no" checked required>No</label>
+          </div>
+          
+          <p>Do you smoke or consume tobaco?</p>
+          <div class="radio-group">
+            <label><input type="radio" name="smoking" value="yes" required>Yes</label>
+            <label><input type="radio" name="smoking" value="no" checked required>No</label>
+          </div>
+  
+          <p>How much alcohol do you drink per day?</p>
+          <div class="radio-group">
+            <label><input type="radio" name="alcohol" value="don't drink at all" checked required>Don't drink at all</label>
+            <label><input type="radio" name="alcohol" value="less than half a cup" required>Less than half a cup</label>
+            <label><input type="radio" name="alcohol" value="between half and 1 cups" required>Between half and 1 cups</label>
+            <label><input type="radio" name="alcohol" value="between 1 and 2 cups" required>Between 1 and 2 cups</label>
+            <label><input type="radio" name="alcohol" value="2 or more cups" required>2 or more cups</label>
+          </div>
+  
+          <p>In the past month, did you feel nervous?</p>
+          <div class="radio-group">
+            <label><input type="radio" name="nervous" value="Not at all" checked required>Not at all</label>
+            <label><input type="radio" name="nervous" value="Just a little" required>Just a little</label>
+            <label><input type="radio" name="nervous" value="Sometimes" required>Sometimes</label>
+            <label><input type="radio" name="nervous" value="Generally" required>Generally</label>
+            <label><input type="radio" name="nervous" value="Every time" required>Every time</label>
+          </div>
+  
+          <p>In the past month, did you feel depressed and like nothing could make you feel better?</p>
+          <div class="radio-group">
+              <label><input type="radio" name="depressed" value="Not at all" required>Not at all</label>
+              <label><input type="radio" name="depressed" value="Just a little" required>Just a little</label>
+              <label><input type="radio" name="depressed" value="Sometimes" required>Sometimes</label>
+              <label><input type="radio" name="depressed" value="Generally" required>Generally</label>
+              <label><input type="radio" name="depressed" value="Every time" required>Every time</label>
+              <label><input type="radio" name="depressed" value="I dont know" checked required>I dont know</label>
+          </div>
+          
+          <p>In the past month, did you feel that anything you did was foolish?</p>
+          <div class="radio-group">
+              <label><input type="radio" name="difficult" value="Not at all" checked required>Not at all</label>
+              <label><input type="radio" name="difficult" value="Just a little" required>Just a little</label>
+              <label><input type="radio" name="difficult" value="Sometimes" required>Sometimes</label>
+              <label><input type="radio" name="difficult" value="Generally" required>Generally</label>
+              <label><input type="radio" name="difficult" value="Every time" required>Every time</label>
+          </div>
+          
+          <p>In the past month, did you feel worthless?</p>
+          <div class="radio-group">
+              <label><input type="radio" name="worthless" value="Not at all" checked required>Not at all</label>
+              <label><input type="radio" name="worthless" value="Just a little" required>Just a little</label>
+              <label><input type="radio" name="worthless" value="Sometimes" required>Sometimes</label>
+              <label><input type="radio" name="worthless" value="Generally" required>Generally</label>
+              <label><input type="radio" name="worthless" value="Every time" required>Every time</label>
+          </div>
+        </section>
+  
+  
+          <!-- Add a div with a unique ID to show the loading spinner -->
+          <div id="loading-spinner" class="hidden">
+              <div class="spinner"></div>
+          </div>
+  
+          <input type="submit" value="Submit">
+      </form>
+      <script>
+          function showLoadingSpinner() {
+              // Show the loading spinner when the form is submitted
+              document.getElementById("loading-spinner").classList.remove("hidden");
+          }
       </script>
-      
-      <p>Have you ever been told you have hypertension? Or are you on treatment for hypertension?</p>
-      <div class="radio-group">
-        <label><input type="radio" name="hypertension" value="yes" required>Yes</label>
-        <label><input type="radio" name="hypertension" value="no" checked required>No</label>
-      </div>
-      
-      <p>Have you ever been told you have diabetes? Or are you on treatment for diabetes?</p>
-      <div class="radio-group">
-        <label><input type="radio" name="diabetes" value="yes" required>Yes</label>
-        <label><input type="radio" name="diabetes" value="no" checked required>No</label>
-      </div>
-      
-      <p>Do you smoke or consume tobaco?</p>
-      <div class="radio-group">
-        <label><input type="radio" name="smoking" value="yes" required>Yes</label>
-        <label><input type="radio" name="smoking" value="no" checked required>No</label>
-      </div>
-
-      <p>How much alcohol do you drink per day?</p>
-      <div class="radio-group">
-        <label><input type="radio" name="alcohol" value="don't drink at all" checked required>Don't drink at all</label>
-        <label><input type="radio" name="alcohol" value="less than half a cup" required>Less than half a cup</label>
-        <label><input type="radio" name="alcohol" value="between half and 1 cups" required>Between half and 1 cups</label>
-        <label><input type="radio" name="alcohol" value="between 1 and 2 cups" required>Between 1 and 2 cups</label>
-        <label><input type="radio" name="alcohol" value="2 or more cups" required>2 or more cups</label>
-      </div>
-
-      <p>In the past month, did you feel nervous?</p>
-      <div class="radio-group">
-        <label><input type="radio" name="nervous" value="Not at all" checked required>Not at all</label>
-        <label><input type="radio" name="nervous" value="Just a little" required>Just a little</label>
-        <label><input type="radio" name="nervous" value="Sometimes" required>Sometimes</label>
-        <label><input type="radio" name="nervous" value="Generally" required>Generally</label>
-        <label><input type="radio" name="nervous" value="Every time" required>Every time</label>
-      </div>
-
-      <p>In the past month, did you feel depressed and like nothing could make you feel better?</p>
-      <div class="radio-group">
-          <label><input type="radio" name="depressed" value="Not at all" required>Not at all</label>
-          <label><input type="radio" name="depressed" value="Just a little" required>Just a little</label>
-          <label><input type="radio" name="depressed" value="Sometimes" required>Sometimes</label>
-          <label><input type="radio" name="depressed" value="Generally" required>Generally</label>
-          <label><input type="radio" name="depressed" value="Every time" required>Every time</label>
-          <label><input type="radio" name="depressed" value="I dont know" checked required>I dont know</label>
-      </div>
-      
-      <p>In the past month, did you feel that anything you did was foolish?</p>
-      <div class="radio-group">
-          <label><input type="radio" name="difficult" value="Not at all" checked required>Not at all</label>
-          <label><input type="radio" name="difficult" value="Just a little" required>Just a little</label>
-          <label><input type="radio" name="difficult" value="Sometimes" required>Sometimes</label>
-          <label><input type="radio" name="difficult" value="Generally" required>Generally</label>
-          <label><input type="radio" name="difficult" value="Every time" required>Every time</label>
-      </div>
-      
-      <p>In the past month, did you feel worthless?</p>
-      <div class="radio-group">
-          <label><input type="radio" name="worthless" value="Not at all" checked required>Not at all</label>
-          <label><input type="radio" name="worthless" value="Just a little" required>Just a little</label>
-          <label><input type="radio" name="worthless" value="Sometimes" required>Sometimes</label>
-          <label><input type="radio" name="worthless" value="Generally" required>Generally</label>
-          <label><input type="radio" name="worthless" value="Every time" required>Every time</label>
-      </div>
-    </section>
-
-
-      <!-- Add a div with a unique ID to show the loading spinner -->
-      <div id="loading-spinner" class="hidden">
-          <div class="spinner"></div>
-      </div>
-
-      <input type="submit" value="Submit">
-  </form>
+  
   <script>
-      function showLoadingSpinner() {
-          // Show the loading spinner when the form is submitted
-          document.getElementById("loading-spinner").classList.remove("hidden");
-      }
-  </script>
-
-<script>
-function toggleDetails() {
-    var detailsSection = document.getElementById("more-details");
-    var toggleButton = document.getElementById("toggle-details");
-
-    if (detailsSection.style.display === "none") {
-        detailsSection.style.display = "block";
-        toggleButton.textContent = "Less Details";
-    } else {
-        detailsSection.style.display = "none";
-        toggleButton.textContent = "More Details";
+    function toggleDetails() {
+        var detailsSection = document.getElementById("more-details");
+        var toggleButton = document.getElementById("toggle-details");
+  
+        if (detailsSection.style.display === "none") {
+            detailsSection.style.display = "block";
+            toggleButton.textContent = "Less Details";
+        } else {
+            detailsSection.style.display = "none";
+            toggleButton.textContent = "More Details";
+        }
     }
-}
-</script>
-
-</body>
-</html>
+  </script>
+  
+  </body>
+  </html>
+  

--- a/templates/form.html
+++ b/templates/form.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Lifestyle-advisor</title>
+    <title>Lifestyle Advisor</title>
     <link rel="stylesheet" type="text/css" href="static/style.css">
 </head>
 <body>

--- a/templates/results.html
+++ b/templates/results.html
@@ -40,7 +40,7 @@
 	</style>
 </head>
 <body>
-	<h1>Lifestyle-advisor</h1>
+	<h1>Lifestyle Advisor</h1>
 	<div class="result-container">
 		{% for line in generated_text.split('\n') %}
 			{% if line.startswith('-') %}

--- a/templates/results.html
+++ b/templates/results.html
@@ -40,7 +40,7 @@
 	</style>
 </head>
 <body>
-	<h1>HealthGPT Lifestyle Advice</h1>
+	<h1>Lifestyle-advisor</h1>
 	<div class="result-container">
 		{% for line in generated_text.split('\n') %}
 			{% if line.startswith('-') %}


### PR DESCRIPTION
Rebrand the content to Lifestyle advisor

re name the url to lifestyle-advisor instead of healthguide

keep the age and input box in same row

Gender add option *prefer not to say (if selected then dont pass gender in the promt)

Make symptoms a text area where user can fill in more details

Keep everyhing else hidden (minimized ) in a section more details. On click expand as before

How much do you walk every day , In a week how many times you exercise more than 30 minutes?, Everyday how many portions of fruits and vegetables do you eat?In the past month, how would you qualify your own sleep?, In the past month, did you feel depressed and like nothing could make you feel better? - replace prefer not to say with 'I dont know”. If the answet is I dont know do not include this in the promt.

replace The person follows (selected_diet) with What diet do you follow?

Which of the following reasons apply to your sleep? Select all that apply., Have you ever been told you have hypertension? Or are you on treatment for hypertension? Have you ever been told you have diabetes? Or are you on treatment for diabetes? Do you smoke? How much alcohol do you drink per day? In the past month, did you feel nervous? In the past month, did you feel that anything you did was foolish? In the past month, did you feel worthless?remove the option ‘Prefer not to say’

Rename do you smoke to Do you smoke or consume tobaco?